### PR TITLE
Testgen 2: Adding testgen functionality into Galois && Sifive Qemu Projects

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/BuildEnvironment.mk
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/BuildEnvironment.mk
@@ -4,7 +4,7 @@
 #
 
 BUILD_DIR = ./build
-CROSS_COMPILE_PREFIX = riscv32-unknown-elf
+CROSS_COMPILE_PREFIX = riscv64-unknown-elf
 
 SDK_DIR = ./freedom-e-sdk
 
@@ -39,6 +39,7 @@ ASMFLAGS += -MT"$@" -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)"
 # Linker arguments __________________________________________
 LDFLAGS :=  -Xlinker --gc-sections -Xlinker --defsym=__stack_size=1K
 LDFLAGS += -O0 -g3
+LDFLAGS += $(ARCH_FLAGS)
 LDFLAGS += -ffunction-sections -fdata-sections --specs=nano.specs
 LDFLAGS += -nostartfiles
 LDFLAGS += -T $(LINKER_SCRIPT)

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/Makefile
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/Makefile
@@ -65,10 +65,6 @@ CFLAGS += -DportasmHANDLE_INTERRUPT=$(INTERRUPT_HANDLER)
 
 # Set up application source, include, and object files for compilation: ______________________
 APP_SRC_DIR = .
-APP_SRC = \
-	$(APP_SRC_DIR)/main.c \
-	$(APP_SRC_DIR)/blinky_demo/main_blinky.c \
-	$(APP_SRC_DIR)/full_demo/main_full.c
 
 APP_ASM = \
 	$(APP_SRC_DIR)/full_demo/RegTest.S
@@ -82,13 +78,37 @@ APP_INCLUDES = \
 	-I $(ARCH_PORTABLE_INC) \
 	-I $(FREERTOS_DIR)/Demo/Common/include
 
+ifeq ($(PROJ_NAME),simple)
+	APP_SRC = \
+		$(APP_SRC_DIR)/main.c \
+		$(APP_SRC_DIR)/blinky_demo/main_blinky.c \
+		$(APP_SRC_DIR)/full_demo/main_full.c
+	VPATH += \
+		$(APP_SRC_DIR)/blinky_demo \
+		$(APP_SRC_DIR)/full_demo \
+		$(APP_SRC_DIR)
+else
+ifeq ($(PROJ_NAME),main_testgen)
+	CFLAGS += -DtestgenOnFreeRTOS
+	APP_SRC = \
+		$(APP_SRC_DIR)/main.c  \
+		$(INC_TESTGEN)/$(TEST_TESTGEN).c \
+		$(INC_TESTGEN)/main_$(TEST_TESTGEN).c \
+		$(wildcard $(INC_TESTGEN)/lib/*.c)
+	VPATH += \
+		$(APP_SRC_DIR) \
+		$(APP_SRC_DIR)/full_demo \
+		$(INC_TESTGEN) \
+		$(INC_TESTGEN)/lib/
+	APP_INCLUDES += -I$(INC_TESTGEN)/lib
+else
+$(error unknown proj: $(PROJ_NAME))
+endif #main_testgen
+endif #simple
+
 APP_BUILD_DIR = $(BUILD_DIR)/app
 APP_OBJS := $(patsubst %.c,$(APP_BUILD_DIR)/%.o,$(notdir $(APP_SRC)))
 APP_OBJS += $(patsubst %.S,$(APP_BUILD_DIR)/%.o,$(notdir $(APP_ASM)))
-VPATH += \
-	$(APP_SRC_DIR)/blinky_demo \
-	$(APP_SRC_DIR)/full_demo \
-	$(APP_SRC_DIR)
 
 DEMO_COMMON_SRC =  \
 	$(FREERTOS_DIR)/Demo/Common/Minimal/EventGroupsDemo.c \

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/main.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/main.c
@@ -79,7 +79,9 @@ or 0 to run the more comprehensive test and demo application. */
  * main_blinky() is used when mainCREATE_SIMPLE_BLINKY_DEMO_ONLY is set to 1.
  * main_full() is used when mainCREATE_SIMPLE_BLINKY_DEMO_ONLY is set to 0.
  */
-#if mainCREATE_SIMPLE_BLINKY_DEMO_ONLY == 1
+#ifdef testgenOnFreeRTOS 
+	extern void main_testgen( void );
+#elif mainCREATE_SIMPLE_BLINKY_DEMO_ONLY == 1
 	extern void main_blinky( void );
 #else
 	extern void main_full( void );
@@ -98,7 +100,11 @@ int main( void )
 {
 	/* The mainCREATE_SIMPLE_BLINKY_DEMO_ONLY setting is described at the top
 	of this file. */
-	#if( mainCREATE_SIMPLE_BLINKY_DEMO_ONLY == 1 )
+	#ifdef testgenOnFreeRTOS 
+	{
+		main_testgen();
+	}
+	#elif( mainCREATE_SIMPLE_BLINKY_DEMO_ONLY == 1 )
 	{
 		main_blinky();
 	}

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
@@ -254,7 +254,18 @@ else
 ifeq ($(PROG),main_uart_malware)
 	CFLAGS += -DmainDEMO_TYPE=11
 else
+ifeq ($(PROG),main_testgen)
+	CFLAGS := $(filter-out -Werror,$(CFLAGS))
+	CFLAGS += -DmainDEMO_TYPE=12 
+	CFLAGS += -DtestgenOnFreeRTOS
+	DEMO_SRC = main.c \
+		$(INC_TESTGEN)/$(TEST_TESTGEN).c \
+		$(INC_TESTGEN)/main_$(TEST_TESTGEN).c \
+		$(wildcard $(INC_TESTGEN)/lib/*.c)
+	INCLUDES += -I$(INC_TESTGEN)/lib	
+else
 $(error unknown demo: $(PROG))
+endif # main_testgen
 endif # main_uart_malware
 endif # main_rtc
 endif # main_uart

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/main.c
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/main.c
@@ -67,6 +67,10 @@ extern void main_peekpoke(void);
 #elif mainDEMO_TYPE == 10
 #pragma message "Demo type 10: RTC test"
 extern void main_rtc(void);
+#elif mainDEMO_TYPE == 12
+#undef configGENERATE_RUN_TIME_STATS
+#pragma message "Demo type 12: Testgen"
+extern void main_testgen(void);
 
 #else
 #error "Unsupported demo type"
@@ -173,6 +177,10 @@ int main(void)
 #elif mainDEMO_TYPE == 10
 	{
 		main_rtc();
+	}
+#elif mainDEMO_TYPE == 12
+	{
+		main_testgen();
 	}
 #endif
 


### PR DESCRIPTION
In [testgen](https://gitlab-ext.galois.com/ssith/testgen), we need to add a flow to run our tests on FreeRTOS on either an FPGA target, or locally on a Qemu target for development. 
What I did in this branch:
1. Adding a "main_testgen" demo option to RISC-V_Galois_P1.
2. Adding a "main_testgen" demo option to RISC-V-Qemu-sifive_e-FreedomStudio.
3. Fixing the build environment of RISC-V-Qemu-sifive_e-FreedomStudio to match the new 64-bit toolchain.