### PR TITLE
separate Testgen Mk environment file

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/Makefile
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/Makefile
@@ -89,18 +89,7 @@ ifeq ($(PROJ_NAME),simple)
 		$(APP_SRC_DIR)
 else
 ifeq ($(PROJ_NAME),main_testgen)
-	CFLAGS += -DtestgenOnFreeRTOS
-	APP_SRC = \
-		$(APP_SRC_DIR)/main.c  \
-		$(INC_TESTGEN)/$(TEST_TESTGEN).c \
-		$(INC_TESTGEN)/main_$(TEST_TESTGEN).c \
-		$(wildcard $(INC_TESTGEN)/lib/*.c)
-	VPATH += \
-		$(APP_SRC_DIR) \
-		$(APP_SRC_DIR)/full_demo \
-		$(INC_TESTGEN) \
-		$(INC_TESTGEN)/lib/
-	APP_INCLUDES += -I$(INC_TESTGEN)/lib
+	include $(INC_TESTGEN)/testgenEnvironment.mk
 else
 $(error unknown proj: $(PROJ_NAME))
 endif #main_testgen

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
@@ -255,14 +255,7 @@ ifeq ($(PROG),main_uart_malware)
 	CFLAGS += -DmainDEMO_TYPE=11
 else
 ifeq ($(PROG),main_testgen)
-	CFLAGS := $(filter-out -Werror,$(CFLAGS))
-	CFLAGS += -DmainDEMO_TYPE=12 
-	CFLAGS += -DtestgenOnFreeRTOS
-	DEMO_SRC = main.c \
-		$(INC_TESTGEN)/$(TEST_TESTGEN).c \
-		$(INC_TESTGEN)/main_$(TEST_TESTGEN).c \
-		$(wildcard $(INC_TESTGEN)/lib/*.c)
-	INCLUDES += -I$(INC_TESTGEN)/lib	
+	include $(INC_TESTGEN)/testgenEnvironment.mk
 else
 $(error unknown demo: $(PROG))
 endif # main_testgen


### PR DESCRIPTION
It should have been done this way form the beginning. Now testgen has all the control without the need to modify this repo. Also, this allows each testgen vulClass to have a custom environment Makefile if needed. The include file points to a dynamic workDir path.