### PR TITLE
Wolfssl on testgen

### DIFF
--- a/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/asn.c
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/asn.c
@@ -2391,7 +2391,11 @@ int ValidateDate(const byte* date, byte format, int dateType)
         if (btoi(date[0]) >= 5)
             certTime.tm_year = 1900;
         else
-            certTime.tm_year = 2000;
+            #ifdef testgenOnFreeRTOS
+                certTime.tm_year = 1950;
+            #else
+                certTime.tm_year = 2000;
+            #endif
     }
     else  { /* format == GENERALIZED_TIME */
         certTime.tm_year += btoi(date[i++]) * 1000;

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/integer.c
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/integer.c
@@ -308,8 +308,7 @@ int mp_grow (mp_int * a, int size)
      */
     #ifdef testgenOnFreeRTOS
       //pass the original size too
-      int useCustomMethod = 7;
-      tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, &useCustomMethod,
+      tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, USE_TESTGEN_REALLOC,
                                          sizeof (mp_digit) * a->alloc);
     #else
       tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, 0,

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/integer.c
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/integer.c
@@ -308,7 +308,7 @@ int mp_grow (mp_int * a, int size)
      */
     #ifdef testgenOnFreeRTOS
       //pass the original size too
-      tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, USE_TESTGEN_REALLOC,
+      tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, (int*) USE_TESTGEN_REALLOC,
                                          sizeof (mp_digit) * a->alloc);
     #else
       tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, 0,

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/integer.c
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/integer.c
@@ -306,8 +306,15 @@ int mp_grow (mp_int * a, int size)
      * in case the operation failed we don't want
      * to overwrite the dp member of a.
      */
-    tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, 0,
-                                       DYNAMIC_TYPE_BIGINT);
+    #ifdef testgenOnFreeRTOS
+      //pass the original size too
+      int useCustomMethod = 7;
+      tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, &useCustomMethod,
+                                         sizeof (mp_digit) * a->alloc);
+    #else
+      tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, 0,
+                                         DYNAMIC_TYPE_BIGINT);
+    #endif
     if (tmp == NULL) {
       /* reallocation failed but "a" is still valid [can be freed] */
       return MP_MEM;

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/random.c
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/random.c
@@ -718,9 +718,11 @@ int wc_InitRng(RNG* rng)
         return MEMORY_E;
     }
 #endif
-
-    ret = wc_GenerateSeed(&rng->seed, key, 32);
-
+    #ifdef testgenOnFreeRTOS
+        ret = testgen_wc_GenerateSeed((uint8_t*) key, 32);
+    #else
+        ret = wc_GenerateSeed(&rng->seed, key, 32);
+    #endif
     if (ret == 0) {
         wc_Arc4SetKey(&rng->cipher, key, sizeof(key));
 

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfssl/ssl.h
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfssl/ssl.h
@@ -922,6 +922,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
                                                              const char* label);
 
 
+#ifndef testgenOnFreeRTOS
 #ifndef _WIN32
     #ifndef NO_WRITEV
         #ifdef __PPU
@@ -935,6 +936,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
                                      int iovcnt);
     #endif
 #endif
+#endif //testgenOnFreeRTOS
 
 
 #ifndef NO_CERTS

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/random.h
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/random.h
@@ -112,6 +112,9 @@ typedef struct RNG {
 
 WOLFSSL_LOCAL
 int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
+#ifdef testgenOnFreeRTOS
+    extern int testgen_wc_GenerateSeed(uint8_t* seed, uint8_t sz);
+#endif
 
 #if defined(HAVE_HASHDRBG) || defined(NO_RC4)
 

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/settings.h
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/settings.h
@@ -55,9 +55,9 @@
 /* #define WOLFSSL_MICROCHIP_PIC32MZ */
 
 /* Uncomment next line if using FreeRTOS */
+/* #define FREERTOS */ 
 #ifdef testgenOnFreeRTOS
-    #define FREERTOS
-    #define NO_FILESYSTEM
+    #include "testgenWolfSSLsettings.h"
 #endif
 
 /* Uncomment next line if using FreeRTOS Windows Simulator */

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/settings.h
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/settings.h
@@ -55,7 +55,10 @@
 /* #define WOLFSSL_MICROCHIP_PIC32MZ */
 
 /* Uncomment next line if using FreeRTOS */
-/* #define FREERTOS */
+#ifdef testgenOnFreeRTOS
+    #define FREERTOS
+    #define NO_FILESYSTEM
+#endif
 
 /* Uncomment next line if using FreeRTOS Windows Simulator */
 /* #define FREERTOS_WINSIM */

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/types.h
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/types.h
@@ -162,6 +162,11 @@
 	/* default to libc stuff */
 	/* XREALLOC is used once in normal math lib, not in fast math lib */
 	/* XFREE on some embeded systems doesn't like free(0) so test  */
+	#ifdef testgenOnFreeRTOS
+		#define XMALLOC(s, h, t) ((void) h, (void) t, pvPortMalloc((s)))
+	    extern void *XREALLOC(void *p, size_t n, void* heap, int type);
+	    #define XFREE(p, h, t) ((void) h, (void) t, vPortFree((p)))
+	#else
 	#if defined(XMALLOC_USER)
 	    /* prototypes for user heap override functions */
 	    #include <stddef.h>  /* for size_t */
@@ -182,6 +187,7 @@
 	    #define XMALLOC(s, h, t)     ((void)h, (void)t, wolfSSL_Malloc((s)))
 	    #define XFREE(p, h, t)       {void* xp = (p); if((xp)) wolfSSL_Free((xp));}
 	    #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n))
+	#endif
 	#endif
 
 	#ifndef STRING_USER

--- a/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/types.h
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfssl/wolfcrypt/types.h
@@ -163,7 +163,7 @@
 	/* XREALLOC is used once in normal math lib, not in fast math lib */
 	/* XFREE on some embeded systems doesn't like free(0) so test  */
 	#ifdef testgenOnFreeRTOS
-		#define XMALLOC(s, h, t) ((void) h, (void) t, pvPortMalloc((s)))
+	    #define XMALLOC(s, h, t) ((void) h, (void) t, pvPortMalloc((s)))
 	    extern void *XREALLOC(void *p, size_t n, void* heap, int type);
 	    #define XFREE(p, h, t) ((void) h, (void) t, vPortFree((p)))
 	#else


### PR DESCRIPTION
This branch adapts WolfSSL source within this FreeRTOS-mirror to our Galois project and to [testgen](https://gitlab-ext.galois.com/ssith/testgen). 
Here's a summary of the modifications:
- Adding the main headers of FreeRTOS-Plus-TCP.
- Adding a custom testgen Settings file to add custom keys like `FREERTOS`, `NO_FILESYSTEM`, `WOLFSSL_SMALL_STACK`, etc.
- Redirect the send and recv functions to use the FreeRTOS-Plus-TCP instead.
- Redirect the malloc/realloc/free to use the FreeRTOS heap_4 functions in addition to a custom `XREALLOC` function.
- `Socket_t` type instead of `int` for `fd`.
- Adjust the time reference for certificates validation for Unix time and openssl time.
- Redirect the generate seed instead of using `/dev/urandom` which I believe is a bug in WolfSSL source since the reference to `/dev/urandom` should not be allowed when the switch `NO_FILESYSTEM` is activated.