### PR TITLE
Adding trace hook macros as an option to testgen

### DIFF
--- a/FreeRTOS/Demo/RISC-V_Galois_P1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/FreeRTOSConfig.h
@@ -168,3 +168,7 @@ header file. */
     }
 
 #endif /* FREERTOS_CONFIG_H */
+
+#ifdef testgenOnFreeRTOS
+    #include "testgenTraceHooks.h"
+#endif


### PR DESCRIPTION
Some tests within testgen will use some custom trace hook macros, and according to [FreeRTOS manual](https://www.freertos.org/rtos-trace-macros.html),  it recommends that:    
*"Macro definitions must occur before the inclusion of FreeRTOS.h. The easiest place to define trace macros is at the bottom of FreeRTOSConfig.h, or in a separate header file that is included from the bottom of FreeRTOSConfig.h."*