### PR TITLE
Adapting Diffie-Hellman codes to testgen

### DIFF
--- a/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/dh.c
+++ b/FreeRTOS-Plus/Source/WolfSSL/wolfcrypt/src/dh.c
@@ -71,19 +71,32 @@ void wc_FreeDhKey(DhKey* key)
 #endif
 }
 
+#ifdef testgenOnFreeRTOS
+    extern void onPrintf (const char * textToPrint, ...); //to report the error
+#endif
 
 static word32 DiscreteLogWorkFactor(word32 n)
 {
-    /* assuming discrete log takes about the same time as factoring */
-    if (n<5)
-        return 0;
-    else
-        return (word32)(2.4 * XPOW((double)n, 1.0/3.0) *
-                XPOW(XLOG((double)n), 2.0/3.0) - 5);
+    #ifdef testgenOnFreeRTOS
+        if (n != 1024) {
+            onPrintf("<INVALID> [DiscreteLogWorkFactor]: Called with a value different than 1024.\n");
+        }
+        return 82; //the actual answer in case n==1024
+    #else
+        /* assuming discrete log takes about the same time as factoring */
+        if (n<5)
+            return 0;
+        else
+            return (word32)(2.4 * XPOW((double)n, 1.0/3.0) *
+                    XPOW(XLOG((double)n), 2.0/3.0) - 5);
+    #endif
 }
 
-
-static int GeneratePrivate(DhKey* key, RNG* rng, byte* priv, word32* privSz)
+#ifdef testgenOnFreeRTOS
+    int GeneratePrivate(DhKey* key, RNG* rng, byte* priv, word32* privSz)
+#else
+    static int GeneratePrivate(DhKey* key, RNG* rng, byte* priv, word32* privSz)
+#endif
 {
     int ret;
     word32 sz = mp_unsigned_bin_size(&key->p);
@@ -101,9 +114,13 @@ static int GeneratePrivate(DhKey* key, RNG* rng, byte* priv, word32* privSz)
     return 0;
 }
 
-
-static int GeneratePublic(DhKey* key, const byte* priv, word32 privSz,
+#ifdef testgenOnFreeRTOS
+    int GeneratePublic(DhKey* key, const byte* priv, word32 privSz,
                           byte* pub, word32* pubSz)
+#else
+    static int GeneratePublic(DhKey* key, const byte* priv, word32 privSz,
+                              byte* pub, word32* pubSz)
+#endif
 {
     int ret = 0;
 


### PR DESCRIPTION
The following modifications are to adapt Diffie-Hellman library to testgen:
* Remove the need for `pow` and `log` from math.h by hardcoding the log discrete value of 1024-bits.
* Remove `static` from "GeneratePublic" and "GeneratePrivate" so that they can be used from outside.

**NOTE:** The setting `HAVE_DH` has to be defined to enable the use of the Diffie-Hellman library.