### PR TITLE
Testgen/wolfssl64bit

### DIFF
--- a/FreeRTOS-Plus/Source/WolfSSL_Galois/src/io.c
+++ b/FreeRTOS-Plus/Source/WolfSSL_Galois/src/io.c
@@ -245,7 +245,12 @@ int EmbedReceive(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     int recvd;
     int err;
     #ifdef testgenOnFreeRTOS
-        Socket_t sd = *(Socket_t*)ctx;
+        #if __riscv_xlen == 64
+            //Due to difference of size of Socket_t and int (size of ssl->rfd and ssl->wfd). ReadCTX and WriteCTX do overlap.
+            Socket_t sd = *(Socket_t*) ((intptr_t) ctx +4);
+        #else
+            Socket_t sd = *(Socket_t*)ctx;
+        #endif
     #else
         int sd = *(int*)ctx;
     #endif

--- a/FreeRTOS-Plus/Source/WolfSSL_Galois/wolfcrypt/src/dh.c
+++ b/FreeRTOS-Plus/Source/WolfSSL_Galois/wolfcrypt/src/dh.c
@@ -93,6 +93,7 @@ static word32 DiscreteLogWorkFactor(word32 n)
 }
 
 #ifdef testgenOnFreeRTOS
+    int GeneratePrivate(DhKey* key, RNG* rng, byte* priv, word32* privSz);
     int GeneratePrivate(DhKey* key, RNG* rng, byte* priv, word32* privSz)
 #else
     static int GeneratePrivate(DhKey* key, RNG* rng, byte* priv, word32* privSz)
@@ -115,6 +116,8 @@ static word32 DiscreteLogWorkFactor(word32 n)
 }
 
 #ifdef testgenOnFreeRTOS
+    int GeneratePublic(DhKey* key, const byte* priv, word32 privSz,
+                          byte* pub, word32* pubSz);
     int GeneratePublic(DhKey* key, const byte* priv, word32 privSz,
                           byte* pub, word32* pubSz)
 #else

--- a/FreeRTOS-Plus/Source/WolfSSL_Galois/wolfcrypt/src/misc.c
+++ b/FreeRTOS-Plus/Source/WolfSSL_Galois/wolfcrypt/src/misc.c
@@ -161,7 +161,11 @@ STATIC INLINE void XorWords(wolfssl_word* r, const wolfssl_word* a, word32 n)
 
 STATIC INLINE void xorbuf(void* buf, const void* mask, word32 count)
 {
-    if (((wolfssl_word)buf | (wolfssl_word)mask | count) % WOLFSSL_WORD_SIZE == 0)
+    #if defined(testgenOnFreeRTOS) && (__riscv_xlen == 64)
+        if (((intptr_t)buf | (intptr_t)mask | count) % WOLFSSL_WORD_SIZE == 0)
+    #else
+        if (((wolfssl_word)buf | (wolfssl_word)mask | count) % WOLFSSL_WORD_SIZE == 0)
+    #endif
         XorWords( (wolfssl_word*)buf,
                   (const wolfssl_word*)mask, count / WOLFSSL_WORD_SIZE);
     else {

--- a/FreeRTOS-Plus/Source/WolfSSL_Galois/wolfcrypt/src/rabbit.c
+++ b/FreeRTOS-Plus/Source/WolfSSL_Galois/wolfcrypt/src/rabbit.c
@@ -202,7 +202,11 @@ static INLINE int DoKey(Rabbit* ctx, const byte* key, const byte* iv)
 int wc_RabbitSetKey(Rabbit* ctx, const byte* key, const byte* iv)
 {
 #ifdef XSTREAM_ALIGN
-    if ((wolfssl_word)key % 4) {
+    #if defined(testgenOnFreeRTOS) && (__riscv_xlen == 64)
+        if ((intptr_t)key % 4) {
+    #else
+        if ((wolfssl_word)key % 4) {
+    #endif
         int alignKey[4];
 
         /* iv aligned in SetIV */
@@ -282,7 +286,11 @@ static INLINE int DoProcess(Rabbit* ctx, byte* output, const byte* input,
 int wc_RabbitProcess(Rabbit* ctx, byte* output, const byte* input, word32 msglen)
 {
 #ifdef XSTREAM_ALIGN
-    if ((wolfssl_word)input % 4 || (wolfssl_word)output % 4) {
+    #if defined(testgenOnFreeRTOS) && (__riscv_xlen == 64)
+        if ((intptr_t)input % 4 || (intptr_t)output % 4) {
+    #else
+        if ((wolfssl_word)input % 4 || (wolfssl_word)output % 4) {
+    #endif
         #ifndef NO_WOLFSSL_ALLOC_ALIGN
             byte* tmp;
             WOLFSSL_MSG("wc_RabbitProcess unaligned");

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/FreeRTOSConfig.h
@@ -100,7 +100,14 @@
 #define configTICK_RATE_HZ ((TickType_t)1000)
 #define configMAX_PRIORITIES (5)
 #define configMINIMAL_STACK_SIZE ((uint32_t)512) /* Can be as low as 60 but some of the demo tasks that use this constant require it to be higher. */
-#define configTOTAL_HEAP_SIZE ((size_t)(256 * 1024))
+#if defined(testgenOnFreeRTOS) && (__riscv_xlen == 64) && defined(useExtraStack)
+    #define configSTACK_DEPTH_TYPE uint32_t //the default ifndef is uint16_t
+#endif
+#if defined(testgenOnFreeRTOS) && (__riscv_xlen == 64) && defined(useExtraHeap)
+    #define configTOTAL_HEAP_SIZE ((size_t)(useExtraHeap * 1024 * 1024))
+#else
+    #define configTOTAL_HEAP_SIZE ((size_t)(256 * 1024))
+#endif
 #define configMAX_TASK_NAME_LEN (16)
 #define configUSE_TRACE_FACILITY 1
 #define configUSE_16_BIT_TICKS 0

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/FreeRTOSConfig.h
@@ -100,11 +100,9 @@
 #define configTICK_RATE_HZ ((TickType_t)1000)
 #define configMAX_PRIORITIES (5)
 #define configMINIMAL_STACK_SIZE ((uint32_t)512) /* Can be as low as 60 but some of the demo tasks that use this constant require it to be higher. */
-#if defined(testgenOnFreeRTOS) && (__riscv_xlen == 64) && defined(useExtraStack)
-    #define configSTACK_DEPTH_TYPE uint32_t //the default ifndef is uint16_t
-#endif
-#if defined(testgenOnFreeRTOS) && (__riscv_xlen == 64) && defined(useExtraHeap)
-    #define configTOTAL_HEAP_SIZE ((size_t)(useExtraHeap * 1024 * 1024))
+#define configSTACK_DEPTH_TYPE uint32_t //the default ifndef is uint16_t
+#ifdef configCUSTOM_HEAP_SIZE
+    #define configTOTAL_HEAP_SIZE ((size_t)(configCUSTOM_HEAP_SIZE * 1024 * 1024))
 #else
     #define configTOTAL_HEAP_SIZE ((size_t)(256 * 1024))
 #endif

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
@@ -354,7 +354,7 @@ PORT_ASM_OBJ = $(PORT_ASM:.S=.o)
 CRT0_OBJ = $(CRT0:.S=.o)
 OBJS = $(CRT0_OBJ) $(PORT_ASM_OBJ) $(PORT_OBJ) $(RTOS_OBJ) $(DEMO_OBJ) $(APP_OBJ) $(CPP_OBJ)
 
-LDFLAGS	 = -T link.ld -nostartfiles -nostdlib $(ARCH) $(ABI)
+LDFLAGS	 += -T link.ld -nostartfiles -nostdlib $(ARCH) $(ABI)
 LIBS	 =  -lc -lgcc
 
 $(info ASFLAGS=$(ASFLAGS))

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/link.ld
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/link.ld
@@ -74,6 +74,7 @@ OUTPUT_ARCH( "riscv" )
 
 _STACK_SIZE = DEFINED(_STACK_SIZE) ? _STACK_SIZE : 4K;
 _HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 256K;
+_DMEM_LENGTH = DEFINED(_DMEM_LENGTH) ? _DMEM_LENGTH : 0x00800000;
 
 /*****************************************************************************
  * Define memory layout
@@ -81,7 +82,7 @@ _HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 256K;
 MEMORY {
    cmem : ORIGIN = 0x80000000, LENGTH = 0x00800000
 	imem : ORIGIN = 0xc0000000, LENGTH = 0x00080000
-	dmem : ORIGIN = 0xc0080000, LENGTH = 0x00800000
+	dmem : ORIGIN = 0xc0080000, LENGTH = _DMEM_LENGTH
 }
 
 /* Specify the default entry point to the program */


### PR DESCRIPTION
To make wolfssl work on FreeRTOS 64-bit. The following needed to be done: 
  
In RISCV_Galois_P1:
* Optional using larger stack and heap.   @podhrmic, I need your confirmation on my modifications to `link.ld` and `FreeRTOSconfig.h`. As usual, nothing changes unless you define the right macros. Also, I added `+=` to the `LDFLAGS` in the Makefile so that I am able to define the macros for `link.ld`. 

In Wolfssl:
* Fix some pointers casting due the mismatch of size when int casting on void.
* A `+4` shift in IOCB_ReadCTX value.