### PR TITLE
main_netboot.c: Fix buffer re-alignment code

### DIFF
--- a/FreeRTOS/Demo/RISC-V_Galois_P1/demo/main_netboot.c
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/demo/main_netboot.c
@@ -215,7 +215,7 @@ static void prvShellCommandBoot(int argc, char **argv)
 			return;
 
 		bufs[i - argi - 1] = staging;
-		staging += (size + STAGING_BUFS_ALIGN - 1) % STAGING_BUFS_ALIGN;
+		staging += size + (-size % STAGING_BUFS_ALIGN);
 	}
 
 	printf("Booting\r\n");


### PR DESCRIPTION
This only matters if using OpenSBI fw_jump-style booting, rather than an
embedded payload.