### PR TITLE
Fixes for bluespec_p3

### DIFF
--- a/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
@@ -2,6 +2,7 @@
 $(info $$PROG is [${PROG}])
 
 configCPU_CLOCK_HZ ?=
+configMTIME_HZ ?=
 
 CCPATH 		?=
 TARGET=$(CCPATH)riscv64-unknown-elf
@@ -360,6 +361,10 @@ CFLAGS += $(OPT) -g3 $(ARCH) $(ABI) $(COMPILER_FLAGS) $(INCLUDES)
 # If configCPU_CLOCK_HZ is not empty, pass it as a definition
 ifneq ($(configCPU_CLOCK_HZ),)
 CFLAGS += -DconfigCPU_CLOCK_HZ=$(configCPU_CLOCK_HZ)
+endif
+# If configMTIME_HZ is not empty, pass it as a definition
+ifneq ($(configMTIME_HZ),)
+CFLAGS += -DconfigMTIME_HZ=$(configMTIME_HZ)
 endif
 # Disable warnings for C++ for now
 CPPFLAGS += $(OPT) -g3 $(ARCH) $(ABI) $(COMPILER_FLAGS) $(INCLUDES)

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/plic_driver.c
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/plic_driver.c
@@ -5,12 +5,13 @@
 
 // Note that there are no assertions or bounds checking on these
 // parameter values.
-static void volatile_memzero(uint8_t *base, unsigned int size);
+static void volatile_memzero32(uint32_t *base, unsigned int size);
 
-static void volatile_memzero(uint8_t *base, unsigned int size)
+static void volatile_memzero32(uint32_t *base, unsigned int size)
 {
-    volatile uint8_t *ptr;
-    for (ptr = base; ptr < (base + size); ptr++)
+    volatile uint32_t *ptr;
+    unsigned int words = (size + sizeof(*ptr) - 1) / sizeof(*ptr);
+    for (ptr = base; ptr < (base + words); ptr++)
     {
         *ptr = 0;
     }
@@ -34,14 +35,17 @@ void PLIC_init(
     }
 
     // Disable all interrupts (don't assume that these registers are reset).
-    volatile_memzero((uint8_t *)(this_plic->base_addr +
-                                 PLIC_ENABLE_OFFSET),
-                     (num_sources + 8) / 8);
+    volatile_memzero32((uint32_t *)(this_plic->base_addr +
+                                    PLIC_ENABLE_OFFSET),
+                       (num_sources + 7) / 8);
 
     // Set all priorities to 0 (equal priority -- don't assume that these are reset).
-    volatile_memzero((uint8_t *)(this_plic->base_addr +
-                                 PLIC_PRIORITY_OFFSET),
-                     (num_sources + 1) << PLIC_PRIORITY_SHIFT_PER_SOURCE);
+    // The 0th entry in the memory map is reserved and so should not be written
+    // to, but is also included in num_sources.
+    volatile_memzero32((uint32_t *)(this_plic->base_addr +
+                                    PLIC_PRIORITY_OFFSET +
+                                    (1 << PLIC_PRIORITY_SHIFT_PER_SOURCE)),
+                       (num_sources - 1) << PLIC_PRIORITY_SHIFT_PER_SOURCE);
 
     // Set the threshold to 0.
     volatile plic_threshold *threshold = (plic_threshold *)(this_plic->base_addr +
@@ -63,22 +67,22 @@ void PLIC_set_threshold(plic_instance_t *this_plic,
 void PLIC_enable_interrupt(plic_instance_t *this_plic, plic_source source)
 {
 
-    volatile uint8_t *current_ptr = (volatile uint8_t *)(this_plic->base_addr +
-                                                         PLIC_ENABLE_OFFSET +
-                                                         (source >> 3));
-    uint8_t current = *current_ptr;
-    current = current | (1 << (source & 0x7));
+    volatile uint32_t *current_ptr = (volatile uint32_t *)(this_plic->base_addr +
+                                                           PLIC_ENABLE_OFFSET +
+                                                           (source >> 5));
+    uint32_t current = *current_ptr;
+    current = current | ((uint32_t)1 << (source & 0x1f));
     *current_ptr = current;
 }
 
 void PLIC_disable_interrupt(plic_instance_t *this_plic, plic_source source)
 {
 
-    volatile uint8_t *current_ptr = (volatile uint8_t *)(this_plic->base_addr +
-                                                         PLIC_ENABLE_OFFSET +
-                                                         (source >> 3));
-    uint8_t current = *current_ptr;
-    current = current & ~((1 << (source & 0x7)));
+    volatile uint32_t *current_ptr = (volatile uint32_t *)(this_plic->base_addr +
+                                                           PLIC_ENABLE_OFFSET +
+                                                           (source >> 5));
+    uint32_t current = *current_ptr;
+    current = current & ~(((uint32_t)1 << (source & 0x1f)));
     *current_ptr = current;
 }
 

--- a/FreeRTOS/Source/portable/GCC/RISC-V/port.c
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/port.c
@@ -49,6 +49,10 @@
 	#warning configMTIMECMP_BASE_ADDRESS must be defined in FreeRTOSConfig.h.  If the target chip includes a memory-mapped mtimecmp register then set configMTIMECMP_BASE_ADDRESS to the mapped address.  Otherwise set configMTIMECMP_BASE_ADDRESS to 0.
 #endif
 
+#ifndef configMTIME_HZ
+	#define configMTIME_HZ configCPU_CLOCK_HZ
+#endif
+
 /* Let the user override the pre-loading of the initial LR with the address of
 prvTaskExitError() in case it messes up unwinding of the stack in the
 debugger. */
@@ -90,7 +94,7 @@ void vPortSetupTimerInterrupt( void ) __attribute__(( weak ));
 /* Used to program the machine timer compare register. */
 uint64_t ullNextTime = 0ULL;
 const uint64_t *pullNextTime = &ullNextTime;
-const size_t uxTimerIncrementsForOneTick = ( size_t ) ( ( configCPU_CLOCK_HZ ) / ( configTICK_RATE_HZ ) ); /* Assumes increment won't go over 32-bits. */
+const size_t uxTimerIncrementsForOneTick = ( size_t ) ( ( configMTIME_HZ ) / ( configTICK_RATE_HZ ) ); /* Assumes increment won't go over 32-bits. */
 uint32_t const ullMachineTimerCompareRegisterBase = configMTIMECMP_BASE_ADDRESS;
 volatile uint64_t * pullMachineTimerCompareRegister = NULL;
 


### PR DESCRIPTION
With these changes I'm able to compile a working netboot client for bluespec_p3 using `make PROG=main_netboot XLEN=64 configCPU_CLOCK_HZ=25000000 configMTIME_HZ=250000`.